### PR TITLE
hofix/resize-bug

### DIFF
--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -115,7 +115,7 @@ const Navbar = () => {
   const [isMobile, setIsMobile] = useState(window.innerWidth < 700);
   const [menuClicked, setMenuClicked] = useState(false);
   useWindowResize((event: React.SyntheticEvent) => {
-    setIsMobile(window.innerWidth < 728);
+    setIsMobile(window.innerWidth < 800);
   });
 
   const user = useSelector((state) => state.user);


### PR DESCRIPTION
Fixes the bug where when window was resized, the navbar page references would go column layout but rest of website would still be desktop.

Closes #34 