### PR TITLE
hide password in requests using bcrypt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3139,6 +3139,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
     "beautiful-react-hooks": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/beautiful-react-hooks/-/beautiful-react-hooks-0.27.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,14 @@
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
     "axios": "^0.19.2",
+    "bcryptjs": "^2.4.3",
     "beautiful-react-hooks": "^0.27.2",
     "concurrently": "^5.3.0",
     "connected-react-router": "^6.8.0",
     "currency.js": "^1.2.2",
     "d3": "^5.16.0",
-    "express": "^4.17.1",
     "dotenv": "^8.2.0",
+    "express": "^4.17.1",
     "fs": "0.0.1-security",
     "json-server": "^0.16.1",
     "local-storage": "^2.0.0",
@@ -44,6 +45,7 @@
     "styled-components": "^5.1.1"
   },
   "scripts": {
+    "frontend": "react-scripts start",
     "start": "concurrently \"react-scripts start\" \"node server/server.js\"",
     "server": "node server.js",
     "build": "react-scripts build",

--- a/server.js
+++ b/server.js
@@ -140,13 +140,16 @@ server.post("/emails", async (req, res, next) => {
 /**************************************** */
 
 /******** User login route ************/
+var bcrypt = require("bcryptjs");
+var salt = bcrypt.genSaltSync(10);
+
 server.get("/login", async (req, res, next) => {
   const username = req.query.username;
   const password = req.query.password;
 
   if (
     username === process.env.ADMIN_USERNAME &&
-    password === process.env.ADMIN_PASSWORD
+    bcrypt.compareSync("password", password)
   ) {
     res.sendStatus(200);
   } else {

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -2,8 +2,13 @@ import axios from "axios";
 import config from "../config";
 import { LOGIN_USER } from "./types";
 
+var bcrypt = require("bcryptjs");
+var salt = bcrypt.genSaltSync(10);
+
 export const loginUser = async (username, password) => {
-  const params = "?username=" + username + "&password=" + password;
+  let hashedPassword = bcrypt.hashSync(password, salt);
+
+  const params = "?username=" + username + "&password=" + hashedPassword;
 
   const response = await axios.get(`${config.endpoint}/login/${params}`);
 
@@ -12,7 +17,7 @@ export const loginUser = async (username, password) => {
       type: LOGIN_USER,
       user: {
         username: username,
-        password: password,
+        password: hashedPassword,
       },
     };
   } else if (response.status === 401) {


### PR DESCRIPTION
**Problem**:

The password was exposed in the URL when logging in and was stored in the local storage of the browser as plain text.

**Solution**:

Hash the password and then save and make requests. Hashes are compared on server-side.

**Testing (you need to run backend locally)**:

Make sure that the plain text user password is not visible anywhere except env file.

**Redux store of user should look like this:**

<img width="540" alt="Screen Shot 2020-10-16 at 6 28 00 PM" src="https://user-images.githubusercontent.com/47438886/96324116-5436d200-0fdd-11eb-8877-49a2cadc1889.png">

**Requests should look like this:**

<img width="477" alt="Screen Shot 2020-10-16 at 6 42 53 PM" src="https://user-images.githubusercontent.com/47438886/96324514-67e33800-0fdf-11eb-8242-c33ce72c3331.png">
