### PR TITLE
differentiate image forms by array index and not image links

### DIFF
--- a/src/components/AddItemPage/ImageForm.jsx
+++ b/src/components/AddItemPage/ImageForm.jsx
@@ -91,7 +91,9 @@ const ImageForm = ({ getArrayOfColours, newItem, setNewItem, hasError }) => {
     setNewItem({
       ...newItem,
       images: newItem.images.filter(
-        (existingImage) => existingImage.imageLink !== image.imageLink
+        (existingImage) =>
+          newItem.images.indexOf(existingImage) !==
+          newItem.images.indexOf(image)
       ),
       thumbnailImage: { imageLink: placeHolderImageLink },
     });
@@ -101,7 +103,7 @@ const ImageForm = ({ getArrayOfColours, newItem, setNewItem, hasError }) => {
     setNewItem({
       ...newItem,
       images: newItem.images.map((img) => {
-        if (image.imageLink === img.imageLink) {
+        if (newItem.images.indexOf(image) === newItem.images.indexOf(img)) {
           img = {
             ...img,
             color: evt.target.value,
@@ -123,7 +125,7 @@ const ImageForm = ({ getArrayOfColours, newItem, setNewItem, hasError }) => {
         imageLink: newImageLink,
       },
       images: newItem.images.map((img) => {
-        if (image.id === img.id) {
+        if (newItem.images.indexOf(image) === newItem.images.indexOf(img)) {
           img = {
             ...img,
             imageLink: newImageLink,


### PR DESCRIPTION
**What the bug was:**

The image forms in the new item/edit item forms were identified with their image link. However, when image links were the same in two different forms, making changes to their dropdown or deleting em changed all images forms with the same link.

**How it was fixed:**

Image forms are now differentiated by an array index which is always unique for each form.

**How to test:**

Make sure changes to one image form are not changing any other image form in any way or form.

close #144 